### PR TITLE
Refine BZ issue leading keywords.

### DIFF
--- a/lib/miq_tools_services/bugzilla.rb
+++ b/lib/miq_tools_services/bugzilla.rb
@@ -15,6 +15,7 @@ module MiqToolsServices
     )
 
     URL_REGEX = %r{https://bugzilla\.redhat\.com//?show_bug\.cgi\?id=(?<bug_id>\d+)}
+    MATCH_REGEX = /^((#{CLOSING_KEYWORDS.join("|")}):?)?\s*#{URL_REGEX}$/i
 
     class << self
       attr_accessor :credentials
@@ -40,7 +41,7 @@ module MiqToolsServices
     def self.ids_in_git_commit_message(message)
       ids = []
       message.each_line.collect do |line|
-        match = /^((#{CLOSING_KEYWORDS.join("|")}):?)?\s*#{URL_REGEX}$/i.match(line)
+        match = MATCH_REGEX.match(line)
         ids << match[:bug_id].to_i if match
       end
       ids

--- a/lib/miq_tools_services/bugzilla.rb
+++ b/lib/miq_tools_services/bugzilla.rb
@@ -2,6 +2,20 @@ module MiqToolsServices
   class Bugzilla
     include ServiceMixin
 
+    CLOSING_KEYWORDS = %w(
+      close
+      closes
+      closed
+      fix
+      fixes
+      fixed
+      resolve
+      resolves
+      resolved
+    )
+
+    URL_REGEX = %r{https://bugzilla\.redhat\.com//?show_bug\.cgi\?id=(?<bug_id>\d+)}
+
     class << self
       attr_accessor :credentials
     end
@@ -26,7 +40,7 @@ module MiqToolsServices
     def self.ids_in_git_commit_message(message)
       ids = []
       message.each_line.collect do |line|
-        match = %r{^(Fixes|Resolves)?\s*https://bugzilla\.redhat\.com//?show_bug\.cgi\?id=(?<bug_id>\d+)$}.match(line)
+        match = /^(#{CLOSING_KEYWORDS.join("|")})?\s*#{URL_REGEX}$/i.match(line)
         ids << match[:bug_id].to_i if match
       end
       ids

--- a/lib/miq_tools_services/bugzilla.rb
+++ b/lib/miq_tools_services/bugzilla.rb
@@ -40,7 +40,7 @@ module MiqToolsServices
     def self.ids_in_git_commit_message(message)
       ids = []
       message.each_line.collect do |line|
-        match = /^(#{CLOSING_KEYWORDS.join("|")})?\s*#{URL_REGEX}$/i.match(line)
+        match = /^((#{CLOSING_KEYWORDS.join("|")}):?)?\s*#{URL_REGEX}$/i.match(line)
         ids << match[:bug_id].to_i if match
       end
       ids

--- a/spec/bugzilla_spec.rb
+++ b/spec/bugzilla_spec.rb
@@ -53,24 +53,18 @@ https://bugzilla.redhat.com//show_bug.cgi?id=123456
       expect(described_class.ids_in_git_commit_message(message)).to eq([123456])
     end
 
-    it "detects an id when the URL is prefixed with 'Fixes'" do
-      message = <<-EOF
+    described_class::CLOSING_KEYWORDS
+      .flat_map { |keyword| [keyword, keyword.capitalize] }
+      .each do |keyword|
+      it "detects an id when the URL is prefixed with closing keyword '#{keyword}'" do
+        message = <<-EOF
 This is a commit message
 
-Fixes https://bugzilla.redhat.com/show_bug.cgi?id=123456
+#{keyword} https://bugzilla.redhat.com/show_bug.cgi?id=123456
 EOF
 
-      expect(described_class.ids_in_git_commit_message(message)).to eq([123_456])
-    end
-
-    it "detects an id when the URL is prefixed with 'Resolves'" do
-      message = <<-EOF
-This is a commit message
-
-Resolves https://bugzilla.redhat.com/show_bug.cgi?id=123456
-EOF
-
-      expect(described_class.ids_in_git_commit_message(message)).to eq([123_456])
+        expect(described_class.ids_in_git_commit_message(message)).to eq([123_456])
+      end
     end
   end
 

--- a/spec/bugzilla_spec.rb
+++ b/spec/bugzilla_spec.rb
@@ -54,7 +54,7 @@ https://bugzilla.redhat.com//show_bug.cgi?id=123456
     end
 
     described_class::CLOSING_KEYWORDS
-      .flat_map { |keyword| [keyword, keyword.capitalize] }
+      .flat_map { |keyword| [keyword, keyword.capitalize, keyword + ":", keyword.capitalize + ":"] }
       .each do |keyword|
       it "detects an id when the URL is prefixed with closing keyword '#{keyword}'" do
         message = <<-EOF


### PR DESCRIPTION
Adds case-insensitive varations of 'close', 'fix' and 'resolve'.

Closes https://github.com/ManageIQ/miq_bot/issues/72