### PR TITLE
Consume less memory in the minitgit service

### DIFF
--- a/lib/miq_tools_services/minigit.rb
+++ b/lib/miq_tools_services/minigit.rb
@@ -91,6 +91,7 @@ module MiqToolsServices
       ret = Hash.new { |h, k| h[k] = [] }
       path = line_number = nil
       output.each_line do |line|
+        # Note: We are intentionally ignoring deletes "-" for now
         case line
         when /^--- (?:a\/)?/
           next
@@ -98,11 +99,9 @@ module MiqToolsServices
           path = $1.chomp
         when /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/
           line_number = $1.to_i
-        when /^([ +-])/
-          if $1 != "-"
-            ret[path] << line_number
-            line_number += 1
-          end
+        when /^[ +]/
+          ret[path] << line_number
+          line_number += 1
         end
       end
       ret

--- a/lib/miq_tools_services/minigit.rb
+++ b/lib/miq_tools_services/minigit.rb
@@ -90,7 +90,7 @@ module MiqToolsServices
 
       ret = Hash.new { |h, k| h[k] = [] }
       path = line_number = nil
-      output.lines.each_with_object(ret) do |line, h|
+      output.each_line do |line|
         case line
         when /^--- (?:a\/)?/
           next
@@ -100,11 +100,12 @@ module MiqToolsServices
           line_number = $1.to_i
         when /^([ +-])/
           if $1 != "-"
-            h[path] << line_number
+            ret[path] << line_number
             line_number += 1
           end
         end
       end
+      ret
     end
 
     def diff_file_names(commit1, commit2 = nil)


### PR DESCRIPTION
* Read the whole diff between two commits one line at a time, not all at once
* Avoid some allocations and logic for the "-" deleted line case