### PR TITLE
Avoid allocating for every line in the diff

### DIFF
--- a/spec/minigit_spec.rb
+++ b/spec/minigit_spec.rb
@@ -152,7 +152,7 @@ new file mode 100644
 index 0000000..b4c1281
 --- /dev/null
 +++ b/new_file.rb
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,3 @@
 +class SomeClass
 +end
 +


### PR DESCRIPTION
We really only need to look at a handful of them.

For this to work, we need the `@@ ..` header line to be accurate... so fix the test, which contained a lie.

@jrafanie inspired me with https://github.com/ManageIQ/miq_tools_services/pull/15, where I spotted this easy further win.
