### PR TITLE
Update PR(branch) related methods to work with the new refs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 rvm:
-- "1.9.3"
-- "2.0"
 - "2.1"
 - "2.2"
 - ruby-head


### PR DESCRIPTION
- Remove unused methods since we are moving away from using local tracking
branches for PRs and moving toward using a bare repo