### PR TITLE
Add clone support

### DIFF
--- a/lib/miq_tools_services/minigit.rb
+++ b/lib/miq_tools_services/minigit.rb
@@ -2,6 +2,16 @@ module MiqToolsServices
   class MiniGit
     include ServiceMixin
 
+    def self.clone(*args)
+      require 'awesome_spawn'
+      STDERR.puts "+ #{AwesomeSpawn.build_command_line("git clone", args)}"
+      STDERR.puts AwesomeSpawn.run!("git clone", :params => args).output
+      true
+    rescue AwesomeSpawn::CommandResultError => err
+      require 'minigit'
+      raise ::MiniGit::GitError.new(["clone"], err.result.error.chomp)
+    end
+
     # All MiniGit methods return stdout which always has a trailing newline
     # that is never wanted, so remove it always.
     def delegate_to_service(method_name, *args)

--- a/miq_tools_services.gemspec
+++ b/miq_tools_services.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "github_api",    "~> 0.11.1"
   spec.add_dependency "active_bugzilla"
   spec.add_dependency "polisher",      "~> 0.10.2"
+  spec.add_dependency "awesome_spawn"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/spec/minigit_spec.rb
+++ b/spec/minigit_spec.rb
@@ -13,6 +13,27 @@ describe MiqToolsServices::MiniGit do
 
   it_should_behave_like "ServiceMixin service"
 
+  context ".clone" do
+    let(:command) { "git clone" }
+    let(:params)  { ["git@example.com:org/repo.git", "destination_dir"] }
+
+    it "when it succeeds" do
+      result = stub_good_run!(command, :params => params)
+      expect(STDERR).to receive(:puts).with("+ #{result.command_line}")
+      expect(STDERR).to receive(:puts)
+
+      expect(described_class.clone(*params)).to be true
+    end
+
+    it "when it fails" do
+      result = stub_bad_run!(command, :params => params)
+      expect(STDERR).to receive(:puts).with("+ #{result.command_line}")
+
+      require 'minigit' # To bring in the classes for testing
+      expect { described_class.clone(*params) }.to raise_error(MiniGit::GitError)
+    end
+  end
+
   context ".bugzilla_ids" do
     it "with no bugs" do
       message = <<-EOF

--- a/spec/minigit_spec.rb
+++ b/spec/minigit_spec.rb
@@ -270,38 +270,38 @@ index 4f807bb..57e5993 100644
 
   context ".pr_branch?" do
     it "with a pr branch" do
-      expect(described_class.pr_branch?("pr/133")).to be_true
+      expect(described_class.pr_branch?("pr/133")).to be_truthy
     end
 
     it "with a regular branch" do
-      expect(described_class.pr_branch?("master")).to be_false
+      expect(described_class.pr_branch?("master")).to be_falsey
     end
   end
 
   context "#pr_branch?" do
     it "with pr branch" do
       with_service do |git|
-        expect(git.pr_branch?("pr/133")).to be_true
+        expect(git.pr_branch?("pr/133")).to be_truthy
       end
     end
 
     it "with regular branch" do
       with_service do |git|
-        expect(git.pr_branch?("master")).to be_false
+        expect(git.pr_branch?("master")).to be_falsey
       end
     end
 
     it "with no branch and current branch is a pr branch" do
       described_class.any_instance.stub(:current_branch => "pr/133")
       with_service do |git|
-        expect(git.pr_branch?).to be_true
+        expect(git.pr_branch?).to be_truthy
       end
     end
 
     it "with no branch and current branch is a regular branch" do
       described_class.any_instance.stub(:current_branch => "master")
       with_service do |git|
-        expect(git.pr_branch?).to be_false
+        expect(git.pr_branch?).to be_falsey
       end
     end
   end

--- a/spec/support/awesome_spawn_helper.rb
+++ b/spec/support/awesome_spawn_helper.rb
@@ -1,0 +1,47 @@
+require 'awesome_spawn'
+
+module AwesomeSpawn
+  module SpecHelper
+    def stub_good_run
+      stub_run(:good, :run, command, options)
+    end
+
+    def stub_bad_run
+      stub_run(:bad, :run, command, options)
+    end
+
+    def stub_good_run!(command, options = {})
+      stub_run(:good, :run!, command, options)
+    end
+
+    def stub_bad_run!(command, options = {})
+      stub_run(:bad, :run!, command, options)
+    end
+
+    private
+
+    def stub_run(mode, method, command, options)
+      output = options[:output] || ""
+      error  = options[:error]  || (mode == :bad ? "Failure" : "")
+      exit_status = options[:exit_status] || (mode == :bad ? 1 : 0)
+
+      params = options[:params]
+      command_line = AwesomeSpawn.build_command_line(command, params)
+
+      args = [command]
+      args << {:params => params} if params
+
+      result = CommandResult.new(command_line, output, error, exit_status)
+      if method == :run! && mode == :bad
+        error_message = "#{command} exit code: #{exit_status}"
+        error = CommandResultError.new(error_message, result)
+        expect(AwesomeSpawn).to receive(method).with(*args).and_raise(error)
+      else
+        expect(AwesomeSpawn).to receive(method).with(*args).and_return(result)
+      end
+      result
+    end
+  end
+end
+
+Object.include AwesomeSpawn::SpecHelper


### PR DESCRIPTION
- Add MiniGit#clone …
  - Add helper module for AwesomeSpawn stubbing.  This should be moved to AwesomeSpawn itself, but keeping it here until that happens.
- Fix RSpec 3 deprecation warnings in minigit_spec.rb